### PR TITLE
Use embed `with` to define scoped variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Yourbase template should extends elao admin theme base:
 ### Drop
 
 ```twig
-{% embed "drop.html.twig" with {
+{% embed "@ElaoAdminTheme/components/drop.html.twig" with {
    menu: [
        { url: '#show', label: 'Consulter' },
        { url: '#edit', label: 'Éditer' },

--- a/README.md
+++ b/README.md
@@ -88,17 +88,15 @@ Yourbase template should extends elao admin theme base:
 ### Drop
 
 ```twig
-{% embed "@ElaoAdminTheme/components/drop.html.twig" only %}
+{% embed "drop.html.twig" with {
+   menu: [
+       { url: '#show', label: 'Consulter' },
+       { url: '#edit', label: 'Éditer' },
+       { url: '#delete', label: 'Supprimer' },
+   ]
+} only %}
     {% block drop_direction 'left' %}
     {% block tooltip_direction 'top' %}
     {% block tooltip_label 'Choisir une action' %}
-    {% block drop_menu %}
-        {% set menu = [
-            { url: '#show', label: 'Consulter' },
-            { url: '#edit', label: 'Éditer' },
-            { url: '#delete', label: 'Supprimer' },
-        ] %}
-        {{ parent() }}
-    {% endblock %}
 {% endembed %}
 ```


### PR DESCRIPTION
Live demo: https://twigfiddle.com/k3e9md

https://twig.symfony.com/doc/3.x/tags/embed.html

Also see https://twig.symfony.com/doc/3.x/tags/with.html to define scoped variables anywhere instead of global ones, when not required.

I think the `tooltip_direction` and `tooltip_icon` should be variables as well, since it's used as strings, not really as blocks. WDYT?